### PR TITLE
Create skeleton for assignment structure

### DIFF
--- a/main.go
+++ b/main.go
@@ -10,6 +10,8 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/spencer-p/cse138/pkg/follower"
+	"github.com/spencer-p/cse138/pkg/leader"
 	"github.com/spencer-p/cse138/pkg/util"
 
 	"github.com/gorilla/mux"
@@ -34,12 +36,16 @@ func main() {
 	envconfig.MustProcess("", &env)
 	log.Printf("Configured: %+v\n", env)
 
-	// Create a mux and route a handler
+	// Create a mux and route handlers
 	r := mux.NewRouter()
 	r.Use(util.WithLog)
-	r.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte("TODO"))
-	})
+	if env.ForwardingAddr == "" {
+		log.Println("Configured as a main instance")
+		leader.Route(r)
+	} else {
+		log.Println("Configured as a follower")
+		follower.Route(r, env.ForwardingAddr)
+	}
 
 	srv := &http.Server{
 		Handler:      r,

--- a/pkg/follower/handlers.go
+++ b/pkg/follower/handlers.go
@@ -1,0 +1,26 @@
+// Package leader implements handlers for follower instances.
+package follower
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/gorilla/mux"
+)
+
+// TODO adam, vineet ?
+
+// follower holds all state that a follower needs to operate.
+type follower struct {
+	addr string
+}
+
+func (f *follower) indexHandler(w http.ResponseWriter, r *http.Request) {
+	fmt.Fprintf(w, "My forwarding address is %s", f.addr)
+}
+
+func Route(r *mux.Router, fwd string) {
+	f := follower{fwd}
+
+	r.HandleFunc("/", f.indexHandler).Methods(http.MethodGet)
+}

--- a/pkg/leader/handlers.go
+++ b/pkg/leader/handlers.go
@@ -1,0 +1,64 @@
+// Package leader implements all behavior specific to a leader instance.
+package leader
+
+import (
+	"log"
+	"net/http"
+	"sync"
+
+	"github.com/gorilla/mux"
+)
+
+const (
+	HELLO = "Hello, world!"
+)
+
+// storage abstracts the volatile kv store for this instance
+type storage struct {
+	store map[string]string
+	m     sync.Mutex
+}
+
+func newStorage() *storage {
+	return &storage{
+		store: make(map[string]string),
+		// Note that the zero value for a mutex is unlocked.
+	}
+}
+
+// Set sets key=value and returns true iff the value replaced an old value.
+func (s *storage) Set(key, value string) bool {
+	s.m.Lock()
+	defer s.m.Unlock()
+
+	old, updating := s.store[key]
+	s.store[key] = value
+
+	log.Printf("Set %q=%q", key, value)
+	if updating {
+		log.Printf("Old value was %q", old)
+	}
+
+	return updating
+}
+
+// Delete removes a key.
+func (s *storage) Delete(key string) {
+	s.m.Lock()
+	defer s.m.Unlock()
+
+	delete(s.store, key)
+
+	log.Printf("Deleted %q\n")
+}
+
+func (s *storage) indexHandler(w http.ResponseWriter, r *http.Request) {
+	w.Write([]byte(HELLO))
+	s.Set("TODO", HELLO)
+}
+
+func Route(r *mux.Router) {
+	s := newStorage()
+
+	r.HandleFunc("/", s.indexHandler).Methods(http.MethodGet)
+}


### PR DESCRIPTION
Implementing a general structure.

HTTP handlers for the main instance go in `pkg/leader` (we can't use the package name "main" for obvious reasons). Similarly, the follower code goes in `pkg/follower`.

I've also done some preliminary work to set up a store in memory.